### PR TITLE
Generate sub-costcodes based off first digit in cost-code

### DIFF
--- a/app.js
+++ b/app.js
@@ -218,7 +218,9 @@ app.post('/events', (req, res) => {
 // Get a list of sub- cost codes (account codes) for a cost code (account code)
 app.get('/accounts/:accountCode/subaccountcodes', (req, res) => {
   const { accountCode } = req.params
-  const numOfSubs = Math.ceil(Math.random() * 10)
+  // First integer in the costcode used to generate a deterministic amount of
+  // sub-cost-codes. e.g S7492 will have 7 sub-cost-codes.
+  const numOfSubs = accountCode[1]
   const subCostCodes = []
   for (let i = 0; i < numOfSubs; i += 1) {
     subCostCodes.push(`${accountCode}-${i}`)


### PR DESCRIPTION
This fixes an issue where the projects app (study management) wouldn't let users save nodes because a sub-cost-code list would be randomly generated for the dropdown menu, but the selected value would be compared against a newer, potentially shorter list and fail.